### PR TITLE
[BUG] 顧客情報更新APIでの部分更新時、既存データが意図せず欠損する

### DIFF
--- a/internal/handler/api/customer_handler.go
+++ b/internal/handler/api/customer_handler.go
@@ -81,7 +81,7 @@ func (h *CustomerHandler) UpdateCustomer(c *gin.Context) {
 	customer.ID = id
 
 	updated, err := h.usecase.UpdateCustomer(&customer)
-	
+
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return

--- a/internal/handler/api/customer_handler.go
+++ b/internal/handler/api/customer_handler.go
@@ -3,6 +3,7 @@ package api
 import (
 	"net/http"
 	"strconv"
+
 	"github.com/gin-gonic/gin"
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/domain"
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/usecase"
@@ -79,12 +80,14 @@ func (h *CustomerHandler) UpdateCustomer(c *gin.Context) {
 	}
 	customer.ID = id
 
-	if err := h.usecase.UpdateCustomer(&customer); err != nil {
+	updated, err := h.usecase.UpdateCustomer(&customer)
+	
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, customer)
+	c.JSON(http.StatusOK, updated)
 }
 
 func (h *CustomerHandler) DeleteCustomer(c *gin.Context) {

--- a/internal/handler/api/deal_handler.go
+++ b/internal/handler/api/deal_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/domain"
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/usecase"
@@ -64,12 +65,14 @@ func (h *DealHandler) UpdateDeal(c *gin.Context) {
 	}
 	deal.ID = id
 
-	if err := h.usecase.UpdateDeal(&deal); err != nil {
+	updated, err := h.usecase.UpdateDeal(&deal)
+
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, deal)
+	c.JSON(http.StatusOK, updated)
 }
 
 // UpdateDealStatus represents the kanban movement
@@ -84,7 +87,7 @@ func (h *DealHandler) UpdateDealStatus(c *gin.Context) {
 		return
 	}
 
-	if err := h.usecase.UpdateDealStatus(id, req.Status, req.AssigneeID); err != nil {
+	if _, err := h.usecase.UpdateDealStatus(id, req.Status, req.AssigneeID); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}

--- a/internal/handler/api/property_handler.go
+++ b/internal/handler/api/property_handler.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"net/http"
+
 	"github.com/gin-gonic/gin"
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/domain"
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/usecase"
@@ -64,12 +65,14 @@ func (h *PropertyHandler) UpdateProperty(c *gin.Context) {
 	}
 	property.ID = id
 
-	if err := h.usecase.UpdateProperty(&property); err != nil {
+	updated, err := h.usecase.UpdateProperty(&property)
+
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
 	}
 
-	c.JSON(http.StatusOK, property)
+	c.JSON(http.StatusOK, updated)
 }
 
 func (h *PropertyHandler) DeleteProperty(c *gin.Context) {

--- a/internal/usecase/customer_usecase.go
+++ b/internal/usecase/customer_usecase.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"errors"
+
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/domain"
 )
 
@@ -37,6 +39,10 @@ func (u *customerUsecase) UpdateCustomer(customer *domain.Customer) (*domain.Cus
 	existing, err := u.repo.FindByID(customer.ID)
 	if err != nil {
 		return nil, err
+	}
+
+	if existing == nil {
+		return nil, errors.New("customer not found")
 	}
 
 	if customer.Name != "" {

--- a/internal/usecase/customer_usecase.go
+++ b/internal/usecase/customer_usecase.go
@@ -1,8 +1,6 @@
 package usecase
 
 import (
-	"fmt"
-
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/domain"
 )
 
@@ -41,7 +39,6 @@ func (u *customerUsecase) UpdateCustomer(customer *domain.Customer) (*domain.Cus
 		return nil, err
 	}
 
-	fmt.Println("customer:", customer)
 	if customer.Name != "" {
 		existing.Name = customer.Name
 	}

--- a/internal/usecase/customer_usecase.go
+++ b/internal/usecase/customer_usecase.go
@@ -1,6 +1,8 @@
 package usecase
 
 import (
+	"fmt"
+
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/domain"
 )
 
@@ -8,7 +10,7 @@ type CustomerUsecase interface {
 	ListCustomers(limit, offset int) ([]*domain.Customer, error)
 	GetCustomer(id string) (*domain.Customer, error)
 	CreateCustomer(customer *domain.Customer) error
-	UpdateCustomer(customer *domain.Customer) error
+	UpdateCustomer(customer *domain.Customer) (*domain.Customer, error)
 	DeleteCustomer(id string) error
 }
 
@@ -33,8 +35,27 @@ func (u *customerUsecase) CreateCustomer(customer *domain.Customer) error {
 	return u.repo.Create(customer)
 }
 
-func (u *customerUsecase) UpdateCustomer(customer *domain.Customer) error {
-	return u.repo.Update(customer)
+func (u *customerUsecase) UpdateCustomer(customer *domain.Customer) (*domain.Customer, error) {
+	existing, err := u.repo.FindByID(customer.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println("customer:", customer)
+	if customer.Name != "" {
+		existing.Name = customer.Name
+	}
+	if customer.Email != nil {
+		existing.Email = customer.Email
+	}
+
+	if customer.Phone != nil {
+		existing.Phone = customer.Phone
+	}
+	if err := u.repo.Update(existing); err != nil {
+		return nil, err
+	}
+	return existing, err
 }
 
 func (u *customerUsecase) DeleteCustomer(id string) error {

--- a/internal/usecase/deal_usecase.go
+++ b/internal/usecase/deal_usecase.go
@@ -2,15 +2,25 @@ package usecase
 
 import (
 	"errors"
+
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/domain"
 )
+
+// 簡易的なステータスバリデーション例
+var validStatuses = map[string]bool{
+	"new_lead":          true,
+	"following_up":      true,
+	"viewing_scheduled": true,
+	"application":       true,
+	"contract":          true,
+}
 
 type DealUsecase interface {
 	ListDeals() ([]*domain.Deal, error)
 	GetDeal(id string) (*domain.Deal, error)
 	CreateDeal(deal *domain.Deal) error
-	UpdateDeal(deal *domain.Deal) error
-	UpdateDealStatus(id, status string, assigneeID *string) error
+	UpdateDeal(deal *domain.Deal) (*domain.Deal, error)
+	UpdateDealStatus(id, status string, assigneeID *string) (*domain.Deal, error)
 	DeleteDeal(id string) error
 }
 
@@ -34,25 +44,70 @@ func (u *dealUsecase) CreateDeal(deal *domain.Deal) error {
 	return u.repo.Create(deal)
 }
 
-func (u *dealUsecase) UpdateDeal(deal *domain.Deal) error {
-	return u.repo.Update(deal)
+func (u *dealUsecase) UpdateDeal(deal *domain.Deal) (*domain.Deal, error) {
+	existing, err := u.repo.FindByID(deal.ID)
+	if err != nil {
+		return nil, err
+	}
+
+	if existing == nil {
+		return nil, errors.New("deal not found")
+	}
+
+	if deal.CustomerName != "" {
+		existing.CustomerName = deal.CustomerName
+	}
+	if deal.PropertyID != nil {
+		existing.PropertyID = deal.PropertyID
+	}
+
+	if deal.AssigneeID != nil {
+		existing.AssigneeID = deal.AssigneeID
+	}
+
+	if deal.Status != "" && !validStatuses[deal.Status] {
+		return nil, errors.New("invalid status transition")
+	}
+
+	if deal.Status != "" {
+		existing.Status = deal.Status
+	}
+
+	if err := u.repo.Update(existing); err != nil {
+		return nil, err
+	}
+
+	return existing, err
 }
 
-func (u *dealUsecase) UpdateDealStatus(id, status string, assigneeID *string) error {
-	// 簡易的なステータスバリデーション例
-	validStatuses := map[string]bool{
-		"new_lead":          true,
-		"following_up":      true,
-		"viewing_scheduled": true,
-		"application":       true,
-		"contract":          true,
+func (u *dealUsecase) UpdateDealStatus(id, status string, assigneeID *string) (*domain.Deal, error) {
+
+	existing, err := u.repo.FindByID(id)
+	if err != nil {
+		return nil, err
 	}
 
-	if !validStatuses[status] {
-		return errors.New("invalid status transition")
+	if existing == nil {
+		return nil, errors.New("deal not found")
 	}
 
-	return u.repo.UpdateStatus(id, status, assigneeID)
+	if assigneeID != nil {
+		existing.AssigneeID = assigneeID
+	}
+
+	if status != "" && !validStatuses[status] {
+		return nil, errors.New("invalid status transition")
+	}
+
+	// ステータスが指定されている場合のみ更新
+	if status != "" {
+		existing.Status = status
+	}
+
+	if err := u.repo.UpdateStatus(id, existing.Status, existing.AssigneeID); err != nil {
+		return nil, err
+	}
+	return existing, nil
 }
 
 func (u *dealUsecase) DeleteDeal(id string) error {

--- a/internal/usecase/property_usecase.go
+++ b/internal/usecase/property_usecase.go
@@ -1,14 +1,24 @@
 package usecase
 
 import (
+	"errors"
+
 	"github.com/yamu-studio/profact-simulated-practical-go/internal/domain"
 )
+
+// 簡易的なステータスバリデーション例
+var validPropertyStatuses = map[string]bool{
+	"available":  true,
+	"reserved":   true,
+	"contracted": true,
+	"inactive":   true,
+}
 
 type PropertyUsecase interface {
 	ListProperties() ([]*domain.Property, error)
 	GetProperty(id string) (*domain.Property, error)
 	CreateProperty(property *domain.Property) error
-	UpdateProperty(property *domain.Property) error
+	UpdateProperty(property *domain.Property) (*domain.Property, error)
 	DeleteProperty(id string) error
 }
 
@@ -32,8 +42,42 @@ func (u *propertyUsecase) CreateProperty(property *domain.Property) error {
 	return u.repo.Create(property)
 }
 
-func (u *propertyUsecase) UpdateProperty(property *domain.Property) error {
-	return u.repo.Update(property)
+func (u *propertyUsecase) UpdateProperty(property *domain.Property) (*domain.Property, error) {
+	existing, err := u.repo.FindByID(property.ID)
+	if err != nil {
+		return nil, err
+	}
+	if existing == nil {
+		return nil, errors.New("property not found")
+	}
+
+	if property.Name != "" {
+		existing.Name = property.Name
+	}
+
+	if property.Rent != 0 {
+		existing.Rent = property.Rent
+	}
+
+	if property.Address != "" {
+		existing.Address = property.Address
+	}
+
+	if property.Layout != nil {
+		existing.Layout = property.Layout
+	}
+
+	if property.Status != "" && !validPropertyStatuses[property.Status] {
+		return nil, errors.New("invalid property status transition")
+	}
+
+	if property.Status != "" {
+		existing.Status = property.Status
+	}
+	if err := u.repo.Update(existing); err != nil {
+		return nil, err
+	}
+	return existing, err
 }
 
 func (u *propertyUsecase) DeleteProperty(id string) error {


### PR DESCRIPTION
## 関連Issue
- #1 

## 変更内容
- ユースケースのUpdateCustomerが更新後のCustomerを返すように変更
- ハンドラーで更新後のデータをレスポンシブとして返すように変更
- 部分更新のロジック追加、ユースケースで既存のデータを取得し、送信されたフィールドの値のみ更新

## 背景 / 課題
データ取得後、JSONパース時にデータが存在しない場合、初期値として空文字もしくはnillが付与されるため、DBに保存する際、適切にエラーハンドングしないと、空がDBにわたり、既存のデータをがNULLとして上書されてします。

そのため、構造体で定義されていた、ポインタ型の文字列を使用し、空の場合のエラーハンドングを追加し、空文字とかnil（値が存在）しない場合は、既存データを更新させない方法で、問題を解決しました。

## レビューポイント(レビューしてほしい観点)
- ロジック妥当か
- 命名や設計どうか

## 確認 / セルフチェック(確認したこと)
- [x] 命名規則やコードスタイルに準拠しているか
- [x] エラーハンドリングが適切に行われているか
- [x] ドキュメント（README等）の更新が必要ないか
- [x] ローカルでの動作確認

## 備考
なし
