### PR TITLE
[FEATURE] カンバンボード一覧APIのレスポンスに顧客名・物件名・担当者名を追加

### DIFF
--- a/internal/domain/deal.go
+++ b/internal/domain/deal.go
@@ -8,6 +8,8 @@ type Deal struct {
 	ID           string     `json:"id"`
 	CustomerID   string     `json:"customer_id"`
 	CustomerName string     `json:"customer_name,omitempty"` // JOINなどで取得した場合
+	PropertyName *string    `json:"property_name,omitempty"`
+	AssigneeName *string    `json:"assignee_name,omitempty"`
 	PropertyID   *string    `json:"property_id"`
 	AssigneeID   *string    `json:"assignee_id"`
 	Status       string     `json:"status"`

--- a/internal/handler/api/deal_handler.go
+++ b/internal/handler/api/deal_handler.go
@@ -71,8 +71,8 @@ func (h *DealHandler) CreateDeal(c *gin.Context) {
 	moveInDate, _ := time.Parse("2006-01-02T15:04:05Z", req.MoveInDate)
 	deal := &domain.Deal{
 		CustomerID: req.CustomerID,
-		PropertyID: &propertyID,
-		AssigneeID: &assigneeID,
+		PropertyID: propertyID,
+		AssigneeID: assigneeID,
 		Status:     req.Status,
 		MoveInDate: &moveInDate,
 	}

--- a/internal/handler/request/deal_reqeust.go
+++ b/internal/handler/request/deal_reqeust.go
@@ -1,11 +1,11 @@
 package request
 
 type CreateDealRequest struct {
-	CustomerID string `json:"customer_id" validate:"required,len=36"`
-	PropertyID string `json:"property_id" validate:"required,len=36"`
-	AssigneeID string `json:"assignee_id" validate:"required,len=36"`
-	Status     string `json:"status" validate:"required,oneof=new_lead following_up viewing_scheduled applying contracted lost"`
-	MoveInDate string `json:"move_in_date" validate:"required,datetime=2006-01-02T15:04:05Z"`
+	CustomerID string  `json:"customer_id" validate:"required,len=36"`
+	PropertyID *string `json:"property_id" validate:"omitempty,len=36"`
+	AssigneeID *string `json:"assignee_id" validate:"omitempty,len=36"`
+	Status     string  `json:"status" validate:"required,oneof=new_lead following_up viewing_scheduled applying contracted lost"`
+	MoveInDate string  `json:"move_in_date" validate:"required,datetime=2006-01-02T15:04:05Z"`
 }
 
 type UpdateDealRequest struct {

--- a/internal/repository/deal_repository.go
+++ b/internal/repository/deal_repository.go
@@ -19,9 +19,13 @@ func (r *dealRepository) FindAll() ([]*domain.Deal, error) {
 	query := `
 		SELECT
 			d.id, d.customer_id, d.property_id, d.assignee_id, d.status, d.move_in_date, d.created_at, d.updated_at,
-			c.name as customer_name
+			c.name as customer_name,
+			p.name as property_name,
+			e.name as assignee_name
 		FROM deals d
 		JOIN customers c ON d.customer_id = c.id
+		LEFT JOIN properties p ON d.property_id = p.id
+  	    LEFT JOIN employees e ON d.assignee_id = e.id
 		ORDER BY d.created_at DESC`
 
 	rows, err := r.db.Query(query)
@@ -43,6 +47,8 @@ func (r *dealRepository) FindAll() ([]*domain.Deal, error) {
 			&deal.CreatedAt,
 			&deal.UpdatedAt,
 			&deal.CustomerName,
+			&deal.PropertyName,
+			&deal.AssigneeName,
 		); err != nil {
 			return nil, err
 		}
@@ -55,9 +61,13 @@ func (r *dealRepository) FindByID(id string) (*domain.Deal, error) {
 	query := `
 		SELECT
 			d.id, d.customer_id, d.property_id, d.assignee_id, d.status, d.move_in_date, d.created_at, d.updated_at,
-			c.name as customer_name
+			c.name as customer_name,
+			p.name as property_name,
+			e.name as assignee_name
 		FROM deals d
 		JOIN customers c ON d.customer_id = c.id
+		LEFT JOIN properties p ON d.property_id = p.id
+  		LEFT JOIN employees e ON d.assignee_id = e.id
 		WHERE d.id = ? LIMIT 1`
 
 	deal := &domain.Deal{}
@@ -71,6 +81,8 @@ func (r *dealRepository) FindByID(id string) (*domain.Deal, error) {
 		&deal.CreatedAt,
 		&deal.UpdatedAt,
 		&deal.CustomerName,
+		&deal.PropertyName,
+		&deal.AssigneeName,
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {


### PR DESCRIPTION
## Resolves  #8 


## 概要
GET /api/deals のレスポンスに `property_name`, `assignee_name` を追加しました。

## 変更内容
- ドメインモデルに `PropertyName`, `AssigneeName` フィールドを追加
- リポジトリの SQL に LEFT JOIN を追加して名前を取得


## レビューポイント
- ロジック妥当か
- パフォーマンス問題ないか
- 命名や設計どうか

## 確認 / セルフチェック(確認したこと)
- [x] 命名規則やコードスタイルに準拠しているか
- [x] ローカルでの動作確認


## 備考
CreateDealRequest の NULL 許容について

現状の CreateDealRequest では property_id, assignee_id が必須になっていますが、
要件にある「提案前の案件は物件が未定」「未アサインの案件は担当者が未定」に対応するため、
作成時も NULL を許可するべきかもしれません。

現状:
  PropertyID string `validate:"required,len=36"`
  AssigneeID string `validate:"required,len=36"`

修正案
  PropertyID *string `validate:"omitempty,len=36"`
  AssigneeID *string `validate:"omitempty,len=36"`

 この件について、今回のPRに含めるべきか、別Issueで対応すべきかも確認したいです。